### PR TITLE
initial UTD baseline commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ wfan0 => [
 ```
 Note: `associated` in TI WI-SUN FAN Contest implies that the TI Wi-SUN FAN Border Router has started.
 
+### Using an external DHCPv6 Server ###
+
+The embedded border router project can be configured to route DHCP traffic up through wfantund.
+To actually handle this traffic, an example server is provided via Docker under the `external-servers` folder. 
+Refer to the readme there to see how to configure and start the containers.
+
 ### Checking if tun Interface is up. ###
 When the stack is up, the TUN interface will be enabled. It can be verified by checking
 

--- a/external-servers/README.md
+++ b/external-servers/README.md
@@ -1,0 +1,17 @@
+# Requirements
+1. Docker Engine
+2. Docker Compose
+
+# How to Run DNSMasq as a DHCPv6 Server
+0. Navigate to this folder
+1. Build the docker image with `docker compose build`
+2. Make sure wfantund is running and the interface and stack are up.
+3. Start the container with `docker compose run --rm dnsmasq`
+    - This will start the server with a sane default configuration; it will listen on interface wfan0 and give addresses out between 2020:abcd::1,2020:abcd::ffff.
+4. If you want to run with a non-standard configuration, pass your command line options in as desired. This will overwrite the default interface and address range.
+    - Start the container with `docker compose run --rm dnsmasq -i wfan1 --dhcp-range 2020:abcd::1,2020:abcd::10,64,336h` to only give out 10 different addresses on interface wfan1, for example
+    - Refer to https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html for more options related to dhcp-range if needed
+
+
+# How to figure out which device has a given IPv6 lease
+1. Since IPv6 addresses given out by Dnsmasq are not based on MAC address, it can be hard to tell just by looking at the IPv6 address which device it refers to. To do so, simply take a look at `/var/lib/misc/dnsmasq.leases` on the DHCPv6 Server to view the leases given to a given DUID. Find the IP address you're curious about, and then refer to the DUID. The DUID is based on the link local address, so the last 48 bits (check this caden) refer to the last 48 bits of the devices MAC address! https://datatracker.ietf.org/doc/html/rfc8415#section-11.4 

--- a/external-servers/dnsmasq/Dockerfile
+++ b/external-servers/dnsmasq/Dockerfile
@@ -1,0 +1,10 @@
+# This could be a lighter image, but for development use ubuntu 22.04 
+FROM ubuntu:22.04
+# Install some utilities 
+RUN sudo apt update && sudo apt install -y nano iproute2 curl systemctl
+# Install dnsmasq
+RUN sudo apt update && sudo apt install -y dnsmasq=2.86-1.1
+# Start dnsmasq and don't use dns, only DHCP
+ENTRYPOINT ["dnsmasq", "-d", "-C", "/dev/null", "-p", "0"]
+# By default assume interface is wfan0 and assign any address from subnet::1 to subnet::ffff
+CMD ["-i", "wfan0", "--dhcp-range", "2020:abcd::1,2020:abcd::ffff,64,336h"]

--- a/external-servers/docker-compose.yml
+++ b/external-servers/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  dnsmasq:
+    build: ./dnsmasq
+    privileged: true
+    environment:
+      - TERM=xterm-256color
+    volumes:
+      - ./test_packets:/test_packets
+    network_mode: host

--- a/src/ncp-spinel/SpinelNCPInstance.cpp
+++ b/src/ncp-spinel/SpinelNCPInstance.cpp
@@ -6844,21 +6844,7 @@ bail:
 void
 SpinelNCPInstance::handle_ncp_spinel_value_inserted(spinel_prop_key_t key, const uint8_t* value_data_ptr, spinel_size_t value_data_len)
 {
-	if (key == SPINEL_PROP_IPV6_ADDRESS_TABLE) {
-			struct in6_addr *addr = NULL;
-			uint8_t prefix_len = 0;
-			uint32_t valid_lifetime = 0xFFFFFFFF;
-			uint32_t preferred_lifetime = 0xFFFFFFFF;
-
-			spinel_datatype_unpack(value_data_ptr, value_data_len, "6CLL", &addr, &prefix_len, &valid_lifetime, &preferred_lifetime);
-
-			if (addr != NULL) {
-				if (!should_filter_address(*addr, prefix_len)) {
-					unicast_address_was_added(kOriginThreadNCP, *addr, prefix_len, valid_lifetime, preferred_lifetime);
-				}
-			}
-
-	} else if (key == SPINEL_PROP_MAC_MAC_FILTER_LIST) {
+	if (key == SPINEL_PROP_MAC_MAC_FILTER_LIST) {
 		unsigned int *entry_ptr = NULL;
 		spinel_size_t entry_len = 0;
 		spinel_ssize_t len = 0;

--- a/src/util/TunnelIPv6Interface.cpp
+++ b/src/util/TunnelIPv6Interface.cpp
@@ -600,11 +600,20 @@ bail:
 	return ret;
 }
 
+in6_addr test_addr = {0};
 
 int
 TunnelIPv6Interface::set_online(bool online)
 {
-	return set_running(online);
+	int status = set_running(online);
+	if (status == 0)
+	{
+		// kWPANTUNDProperty_IPv6WfantundGlobalAddress;
+		syslog(LOG_INFO, "Trying to add default Global IP address to %s. . .", mInterfaceName.c_str());
+		test_addr = {0x20,0x20,0xAB,0xCD, 0,0,0,0, 0,0,0,0, 0,0,0,0};
+		add_address(&test_addr, 64);
+	}
+	return status;
 }
 
 void


### PR DESCRIPTION
This commit adds support for running dnsmasq as a Docker Container to supply IPv6 addresses to nodes that join the border router. It also assigns the wfan interface a default address of "2020:ABCD::". Finally, it includes a readme for how to use dnsmasq.